### PR TITLE
Export types as vega and vega-lib

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
 declare module 'vega' {
   export * from 'vega-typings';
 }
+
+declare module 'vega-lib' {
+  export * from 'vega-typings';
+}


### PR DESCRIPTION
This is related to https://github.com/vega/vega-typings/issues/13. 

We had build issues in jupyterlab (https://github.com/jupyterlab/jupyterlab/pull/4233). This PR should fix them. 