### PR TITLE
Use minified versions in CDNs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   "main": "build/vega.js",
   "module": "index",
   "jsnext:main": "index",
+  "unpkg": "build/vega.min.js",
+  "jsdelivr": "build/vega.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/vega/vega-lib.git"


### PR DESCRIPTION
https://unpkg.com/vega-lib@3.3.1 downloads the non-minified version of Vega. In this PR, we tell CDNs to use the minified version instead.

This will improve performance for https://github.com/observablehq/vega/pull/9. 