### PR TITLE
export the schemeDiscretized function from vega-scale

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ export {
 export {
   scale,
   scheme,
+  schemeDiscretized,
   interpolate,
   interpolateRange,
   timeInterval,


### PR DESCRIPTION
The export of `schemeDiscretized` from vega-scale is missing. This PR adds the export to expose it on the vega object.